### PR TITLE
Fix `if` behavior: Treat as a statement instead of a non-evaluating expression 

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -24,6 +24,7 @@ pub enum Stmt {
 	ConstDel(ConstDelStmt),
 	ConstFn(ConstFnStmt),
 	Block(BlockStmt),
+	If(IfStmt),
 
 	// loop
 	While(WhileStmt),
@@ -44,6 +45,7 @@ impl Stmt {
 			Stmt::ConstDel(const_del) => const_del.get_range(),
 			Stmt::ConstFn(const_stmt) => const_stmt.get_range(),
 			Stmt::Ret(ret_stmt) => ret_stmt.get_range(),
+			Stmt::If(if_stmt) => if_stmt.get_range(),
 			Stmt::ExternFn(extern_fn_stmt) => extern_fn_stmt.get_range(),
 			Stmt::While(while_stmt) => while_stmt.get_range(),
 			Stmt::For(for_stmt) => for_stmt.get_range(),
@@ -87,6 +89,23 @@ impl RetStmt {
 	}
 	pub fn get_type_id(&self) -> Option<TypeId> {
 		self.type_id
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IfStmt {
+	pub cond: Box<Expr>,
+	pub then: Box<Stmt>,
+	pub otherwise: Option<Box<Stmt>>,
+	pub range: Range, // if range
+}
+
+impl IfStmt {
+	pub fn get_range(&self) -> Range {
+		match &self.otherwise {
+			Some(otherwise) => self.range.merged_with(&otherwise.get_range()),
+			None => self.range.merged_with(&self.then.get_range()),
+		}
 	}
 }
 
@@ -505,7 +524,6 @@ pub enum Expr {
 	Pipe(PipeExpr),
 	Unary(UnaryExpr),
 	Call(CallExpr),
-	If(IfExpr),
 	Import(ImportExpr),
 	Ident(Ident),
 	Literal(Literal),
@@ -523,7 +541,6 @@ impl Expr {
 			Expr::Pipe(pipe) => pipe.get_range(),
 			Expr::Unary(unary) => unary.get_range(),
 			Expr::Call(call) => call.get_range(),
-			Expr::If(if_expr) => if_expr.get_range(),
 			// Expr::Ret(ret_expr) => ret_expr.get_range(),
 			Expr::Ident(ident) => ident.get_range(),
 			Expr::Assign(assign) => assign.get_range(),
@@ -770,23 +787,6 @@ impl CallExpr {
 	}
 	pub fn get_args_type(&self) -> &Vec<TypeId> {
 		&self.args_type
-	}
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct IfExpr {
-	pub cond: Box<Expr>,
-	pub then: Box<Stmt>,
-	pub otherwise: Option<Box<Stmt>>,
-	pub range: Range, // if range
-}
-
-impl IfExpr {
-	pub fn get_range(&self) -> Range {
-		match &self.otherwise {
-			Some(otherwise) => self.range.merged_with(&otherwise.get_range()),
-			None => self.range.merged_with(&self.then.get_range()),
-		}
 	}
 }
 

--- a/src/builder/build_expr.rs
+++ b/src/builder/build_expr.rs
@@ -11,7 +11,6 @@ impl Builder<'_> {
 			ast::Expr::Call(call_expr) => self.build_call_expr(call_expr),
 			ast::Expr::Deref(deref_expr) => self.build_deref_expr(deref_expr),
 			ast::Expr::Ident(ident_expr) => self.build_ident_expr(ident_expr),
-			ast::Expr::If(if_expr) => self.build_if_expr(if_expr),
 			ast::Expr::Literal(literal) => self.build_literal(literal),
 			ast::Expr::StructInit(struct_init_expr) => self.build_struct_init_expr(struct_init_expr),
 			ast::Expr::Member(member_expr) => self.build_member_expr(member_expr),

--- a/src/builder/build_if_stmt.rs
+++ b/src/builder/build_if_stmt.rs
@@ -1,10 +1,10 @@
 use crate::ast;
-use crate::ir::{self, IrBasicValue};
+use crate::ir::{self};
 
 use super::Builder;
 
 impl Builder<'_> {
-	pub fn build_if_expr(&mut self, if_expr: &mut ast::IfExpr) -> IrBasicValue {
+	pub fn build_if_stmt(&mut self, if_expr: &mut ast::IfStmt) {
 		let cond = self.build_expr(&mut if_expr.cond);
 		let then_block = self.ctx.block.new_block();
 		let otherwise_block = if_expr.otherwise.as_ref().map(|_| self.ctx.block.new_block());
@@ -32,6 +32,5 @@ impl Builder<'_> {
 			}
 		}
 		self.ctx.block.switch_to_block(merge_block);
-		IrBasicValue::default()
 	}
 }

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -20,7 +20,7 @@ mod build_block_stmt;
 mod build_extern_fn_stmt;
 mod build_fn_stmt;
 mod build_ident_expr;
-mod build_if_expr;
+mod build_if_stmt;
 mod build_impl_stmt;
 mod build_let_stmt;
 mod build_literal;
@@ -80,6 +80,7 @@ impl<'br> Builder<'br> {
 			ast::Stmt::ExternFn(extern_fn_stmt) => self.build_extern_fn_stmt(extern_fn_stmt),
 			ast::Stmt::Block(block_stmt) => self.build_block_stmt(block_stmt),
 			ast::Stmt::Ret(ret_stmt) => self.build_ret_stmt(ret_stmt),
+			ast::Stmt::If(if_stmt) => self.build_if_stmt(if_stmt),
 			ast::Stmt::TypeDef(type_def) => self.build_type_def_stmt(type_def),
 			// ast::Stmt::While(while_stmt) => self.build_while_stmt(while_stmt),
 			// ast::Stmt::For(for_stmt) => self.build_for_stmt(for_stmt),

--- a/src/checker/check_expr.rs
+++ b/src/checker/check_expr.rs
@@ -12,7 +12,6 @@ impl Checker<'_> {
 			ast::Expr::Assign(assign_expr) => self.check_assign_expr(assign_expr),
 			ast::Expr::Ident(ident_expr) => self.check_ident_expr(ident_expr),
 			ast::Expr::Call(call_expr) => self.check_call_expr(call_expr),
-			ast::Expr::If(if_expr) => self.check_if_expr(if_expr),
 			ast::Expr::StructInit(stuct_init_expr) => self.check_struct_init_expr(stuct_init_expr),
 			ast::Expr::Import(import_expr) => self.check_import_expr(import_expr),
 			ast::Expr::Associate(associate_expr) => self.check_associate_expr(associate_expr),

--- a/src/checker/check_if_stmt.rs
+++ b/src/checker/check_if_stmt.rs
@@ -3,7 +3,7 @@ use super::{Checker, TyResult};
 use crate::ast;
 
 impl Checker<'_> {
-	pub fn check_if_expr(&mut self, if_expr: &mut ast::IfExpr) -> TyResult<TypeId> {
+	pub fn check_if_stmt(&mut self, if_expr: &mut ast::IfStmt) -> TyResult<TypeId> {
 		let cond_type = self.check_expr(&mut if_expr.cond)?;
 		self.equal_type_expected(TypeId::BOOL, cond_type, if_expr.cond.get_range())?;
 
@@ -11,8 +11,10 @@ impl Checker<'_> {
 
 		if let Some(otherwise) = &mut if_expr.otherwise {
 			let otherwise_type = self.check_stmt(otherwise)?;
-			return Ok(otherwise_type);
+			// return Ok(otherwise_type);
 		}
+
+		// TODO: unify types of then and otherwise branches
 
 		Ok(then_type)
 	}

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -24,7 +24,7 @@ mod check_extern_fn_stmt;
 mod check_fn_stmt;
 mod check_for_stmt;
 mod check_ident_expr;
-mod check_if_expr;
+mod check_if_stmt;
 mod check_impl_stmt;
 mod check_import_expr;
 mod check_let_stmt;
@@ -69,6 +69,7 @@ impl<'ckr> Checker<'ckr> {
 			ast::Stmt::ConstDel(const_del) => self.check_const_del_stmt(const_del),
 			ast::Stmt::ConstFn(const_fn) => self.check_const_fn_stmt(const_fn),
 			ast::Stmt::Ret(ret_stmt) => self.check_ret_stmt(ret_stmt),
+			ast::Stmt::If(if_stmt) => self.check_if_stmt(if_stmt),
 			ast::Stmt::ExternFn(extern_fn_stmt) => self.check_extern_fn_stmt(extern_fn_stmt),
 			ast::Stmt::TypeDef(type_def_stmt) => self.check_type_def_stmt(type_def_stmt),
 			ast::Stmt::Impl(impl_stmt) => self.check_impl_stmt(impl_stmt),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -44,6 +44,7 @@ impl<'lex> Parser<'lex> {
 			Some(Token::Fn) => self.parse_fn_stmt().map(ast::Stmt::Fn),
 			Some(Token::LBrace) => self.parse_block_stmt().map(ast::Stmt::Block),
 			Some(Token::Ret) => self.parse_ret_stmt().map(ast::Stmt::Ret),
+			Some(Token::If) => self.parse_if_stmt().map(ast::Stmt::If),
 			Some(Token::Extern) => self.parse_extern_fn_stmt().map(ast::Stmt::ExternFn),
 			Some(Token::While) => self.parse_while_stmt().map(ast::Stmt::While),
 			Some(Token::For) => self.parse_for_stmt().map(ast::Stmt::For),
@@ -114,6 +115,20 @@ impl<'lex> Parser<'lex> {
 			return self.parse_const_fn_stmt(range).map(ast::Stmt::ConstFn);
 		}
 		self.parse_const_del_stmt(range).map(ast::Stmt::ConstDel)
+	}
+
+	fn parse_if_stmt(&mut self) -> PResult<'lex, ast::IfStmt> {
+		let range = self.expect(Token::If)?;
+		self.expect(Token::LParen)?; // take '('
+		let cond = Box::new(self.parse_expr(MIN_PDE)?);
+		self.expect(Token::RParen)?; // take ')'
+		let then = Box::new(self.parse_stmt()?);
+		let mut otherwise = None;
+		if self.match_token(Token::Else) {
+			self.expect(Token::Else)?;
+			otherwise = Some(Box::new(self.parse_stmt()?));
+		}
+		Ok(ast::IfStmt { cond, then, otherwise, range })
 	}
 
 	fn parse_const_fn_stmt(&mut self, range: Range) -> PResult<'lex, ast::ConstFnStmt> {
@@ -384,7 +399,6 @@ impl<'lex> Parser<'lex> {
 			Some(Token::Char) => self.parse_char().map(ast::Expr::Literal)?,
 			Some(Token::String) => self.parse_string().map(ast::Expr::Literal)?,
 			Some(Token::Fn) => self.parse_fn_expr().map(ast::Expr::Fn)?,
-			Some(Token::If) => self.parse_if_expr().map(ast::Expr::If)?,
 			Some(Token::Import) => self.parse_import_expr().map(ast::Expr::Import)?,
 			Some(Token::Decimal) | Some(Token::Hex) | Some(Token::Bin) => {
 				self.parse_numb().map(ast::Expr::Literal)?
@@ -582,20 +596,6 @@ impl<'lex> Parser<'lex> {
 		let body = Box::new(self.parse_stmt()?);
 
 		Ok(ast::FnExpr { params, body, range, ret_type, type_id: None })
-	}
-
-	fn parse_if_expr(&mut self) -> PResult<'lex, ast::IfExpr> {
-		let range = self.expect(Token::If)?;
-		self.expect(Token::LParen)?; // take '('
-		let cond = Box::new(self.parse_expr(MIN_PDE)?);
-		self.expect(Token::RParen)?; // take ')'
-		let then = Box::new(self.parse_stmt()?);
-		let mut otherwise = None;
-		if self.match_token(Token::Else) {
-			self.expect(Token::Else)?;
-			otherwise = Some(Box::new(self.parse_stmt()?));
-		}
-		Ok(ast::IfExpr { cond, then, otherwise, range })
 	}
 
 	fn parse_call_expr(&mut self, callee: ast::Expr) -> PResult<'lex, ast::Expr> {


### PR DESCRIPTION
Previously, `if` was treated as an expression but did not evaluate to a value,  
leading to inconsistent behavior. This change ensures that `if` is strictly a  
statement, preventing misuse in expression contexts.  