### PR TITLE
Add support for If Expression

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -465,6 +465,7 @@ impl Binding {
 pub enum Expr {
 	Group(GroupExpr),
 	Fn(FnExpr),
+	If(IfExpr),
 	Assign(AssignExpr),
 	Associate(AssociateExpr),
 	Member(MemberExpr),
@@ -492,7 +493,7 @@ impl Expr {
 			Expr::Pipe(pipe) => pipe.get_range(),
 			Expr::Unary(unary) => unary.get_range(),
 			Expr::Call(call) => call.get_range(),
-			// Expr::Ret(ret_expr) => ret_expr.get_range(),
+			Expr::If(if_expr) => if_expr.get_range(),
 			Expr::Ident(ident) => ident.get_range(),
 			Expr::Assign(assign) => assign.get_range(),
 			Expr::Literal(literal) => literal.get_range(),
@@ -559,6 +560,24 @@ impl FnExpr {
 	#[inline(always)]
 	pub fn get_range(&self) -> Range {
 		self.range.merged_with(&self.body.get_range())
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IfExpr {
+	pub cond: Box<Expr>,
+	pub then: Box<Expr>,
+	pub otherwise: Box<Expr>,
+	pub range: Range, // if range
+}
+
+impl IfExpr {
+	pub fn new(cond: Box<Expr>, then: Box<Expr>, otherwise: Box<Expr>, range: Range) -> Self {
+		Self { cond, then, otherwise, range }
+	}
+	#[inline(always)]
+	pub fn get_range(&self) -> Range {
+		self.range.merged_with(&self.otherwise.get_range())
 	}
 }
 

--- a/src/builder/build_expr.rs
+++ b/src/builder/build_expr.rs
@@ -9,6 +9,7 @@ impl Builder<'_> {
 			ast::Expr::Binary(binary_expr) => self.build_binary_expr(binary_expr),
 			ast::Expr::Borrow(borrow_expr) => self.build_borrow_expr(borrow_expr),
 			ast::Expr::Call(call_expr) => self.build_call_expr(call_expr),
+			ast::Expr::If(if_expr) => self.build_if_expr(if_expr),
 			ast::Expr::Deref(deref_expr) => self.build_deref_expr(deref_expr),
 			ast::Expr::Ident(ident_expr) => self.build_ident_expr(ident_expr),
 			ast::Expr::Literal(literal) => self.build_literal(literal),

--- a/src/builder/build_if_expr.rs
+++ b/src/builder/build_if_expr.rs
@@ -1,0 +1,74 @@
+use crate::ast;
+use crate::ir;
+
+use super::Builder;
+
+impl Builder<'_> {
+	pub fn build_if_expr(&mut self, if_expr: &mut ast::IfExpr) -> ir::IrBasicValue {
+		let range = if_expr.get_range();
+		let type_id = self.lookup_event_type(range);
+		let dest = self.ctx.create_register(type_id);
+		let alloc_instr = ir::SallocInstr::new(dest.clone(), type_id);
+		let result = self.ctx.current_block.append_instr(alloc_instr.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+
+		// blocks
+		let then_block = self.ctx.current_block.create_new_block();
+		let otherwise_block = self.ctx.current_block.create_new_block();
+		let merge_block = self.ctx.current_block.create_new_block();
+
+		// cond
+		let cond = self.build_expr(&mut if_expr.cond);
+		let cond_instr = ir::JmpIfInstr::new(cond, then_block.into(), otherwise_block.into());
+		let result = self.ctx.current_block.append_instr(cond_instr.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+
+		// then
+		let result = self.ctx.current_block.switch_to_label(then_block.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+		let then = self.build_expr(&mut if_expr.then);
+		let then = self.resolve_value(then, range);
+		let set_instr = ir::UnInstr::new(dest.clone(), then);
+		let result = self.ctx.current_block.append_instr(ir::Instr::Set(set_instr));
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+		let jmp_instr = ir::JmpInstr::new(merge_block.into());
+		let result = self.ctx.current_block.append_instr(jmp_instr.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+
+		// otherwise
+		let result = self.ctx.current_block.switch_to_label(otherwise_block.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+		let otherwise = self.build_expr(&mut if_expr.otherwise);
+		let otherwise = self.resolve_value(otherwise, range).with_new_type(type_id);
+		let set_instr = ir::UnInstr::new(dest.clone(), otherwise);
+		let result = self.ctx.current_block.append_instr(ir::Instr::Set(set_instr));
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+		let jmp_instr = ir::JmpInstr::new(merge_block.into());
+		let result = self.ctx.current_block.append_instr(jmp_instr.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+
+		// pass control to the merge block
+		let result = self.ctx.current_block.switch_to_label(merge_block.into());
+		result.unwrap_or_else(|message| {
+			message.mod_id(self.mod_id_unchecked()).range(range).report(self.loader)
+		});
+
+		self.resolve_value(dest, range)
+	}
+}

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -13,6 +13,7 @@ mod build_assign_expr;
 mod build_binary_expr;
 mod build_borrow_expr;
 mod build_call_expr;
+mod build_if_expr;
 
 mod build_deref_expr;
 mod build_expr;

--- a/src/checker/check_expr.rs
+++ b/src/checker/check_expr.rs
@@ -12,6 +12,7 @@ impl Checker<'_> {
 			ast::Expr::Assign(assign_expr) => self.check_assign_expr(assign_expr),
 			ast::Expr::Ident(ident_expr) => self.check_ident_expr(ident_expr),
 			ast::Expr::Call(call_expr) => self.check_call_expr(call_expr),
+			ast::Expr::If(if_expr) => self.check_if_expr(if_expr),
 			ast::Expr::StructInit(stuct_init_expr) => self.check_struct_init_expr(stuct_init_expr),
 			ast::Expr::Import(import_expr) => self.check_import_expr(import_expr),
 			ast::Expr::Associate(associate_expr) => self.check_associate_expr(associate_expr),

--- a/src/checker/check_if_expr.rs
+++ b/src/checker/check_if_expr.rs
@@ -7,14 +7,14 @@ impl Checker<'_> {
 	pub fn check_if_expr(&mut self, if_expr: &mut ast::IfExpr) -> MessageResult<TypedValue> {
 		let cond_type = self.check_expr(&mut if_expr.cond)?;
 		self.equal_type_expected(TypeId::BOOL, cond_type.type_id, if_expr.cond.get_range())?;
-		let then_type = self.check_expr(&mut if_expr.then)?;
-		let otherwise_type = self.check_expr(&mut if_expr.otherwise)?;
-		println!("{}", self.equal_type_id(then_type.type_id, otherwise_type.type_id));
-		self.equal_type_expected(
-			then_type.type_id,
-			otherwise_type.type_id,
-			if_expr.otherwise.get_range(),
-		)?;
-		Ok(TypedValue { type_id: then_type.type_id, ptr: 0 })
+		let then = self.check_expr(&mut if_expr.then)?;
+		let otherwise = self.check_expr(&mut if_expr.otherwise)?;
+		let if_expr_typed = match self.unify_types(then.type_id, otherwise.type_id)? {
+			Some(unified_type) => unified_type,
+			None => {
+				self.equal_type_expected(then.type_id, otherwise.type_id, if_expr.otherwise.get_range())?
+			}
+		};
+		Ok(TypedValue { type_id: if_expr_typed, ptr: 0 })
 	}
 }

--- a/src/checker/check_if_expr.rs
+++ b/src/checker/check_if_expr.rs
@@ -1,0 +1,20 @@
+use super::types::TypeId;
+use super::{Checker, TypedValue};
+use crate::ast;
+use crate::message::MessageResult;
+
+impl Checker<'_> {
+	pub fn check_if_expr(&mut self, if_expr: &mut ast::IfExpr) -> MessageResult<TypedValue> {
+		let cond_type = self.check_expr(&mut if_expr.cond)?;
+		self.equal_type_expected(TypeId::BOOL, cond_type.type_id, if_expr.cond.get_range())?;
+		let then_type = self.check_expr(&mut if_expr.then)?;
+		let otherwise_type = self.check_expr(&mut if_expr.otherwise)?;
+		println!("{}", self.equal_type_id(then_type.type_id, otherwise_type.type_id));
+		self.equal_type_expected(
+			then_type.type_id,
+			otherwise_type.type_id,
+			if_expr.otherwise.get_range(),
+		)?;
+		Ok(TypedValue { type_id: then_type.type_id, ptr: 0 })
+	}
+}

--- a/src/checker/check_if_expr.rs
+++ b/src/checker/check_if_expr.rs
@@ -15,6 +15,7 @@ impl Checker<'_> {
 				self.equal_type_expected(then.type_id, otherwise.type_id, if_expr.otherwise.get_range())?
 			}
 		};
-		Ok(TypedValue { type_id: if_expr_typed, ptr: 0 })
+		self.register_type(if_expr_typed, if_expr.get_range());
+		Ok(self.owned_typed_value(if_expr_typed))
 	}
 }

--- a/src/checker/equal_type.rs
+++ b/src/checker/equal_type.rs
@@ -24,12 +24,12 @@ impl Checker<'_> {
 		expected: TypeId,
 		found: TypeId,
 		range: Range,
-	) -> MessageResult<()> {
+	) -> MessageResult<TypeId> {
 		if !self.equal_type_id(expected, found) {
 			let expected = self.display_type(expected);
 			let found = self.display_type(found);
 			return Err(SyntaxErr::type_mismatch(expected, found, range));
 		}
-		Ok(())
+		Ok(expected)
 	}
 }

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -30,6 +30,7 @@ mod check_extern_fn_stmt;
 mod check_fn_stmt;
 mod check_for_stmt;
 mod check_ident_expr;
+mod check_if_expr;
 mod check_if_stmt;
 mod check_impl_stmt;
 mod check_import_expr;

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -65,12 +65,13 @@ pub fn compile(path_name: &str, matches: &ArgMatches) {
 
 	// optimize::optimize(&mut ir);
 
-	if true {
+	if matches.get_flag("lnr") {
 		let disassembler = Disassembler::new(&ctx.type_store);
 		println!();
 		let mut ir_text = String::new();
 		disassembler.disassemble_program(&ir, &mut ir_text);
 		println!("{}", ir_text);
+		return;
 	}
 
 	// emit llvm

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -65,13 +65,12 @@ pub fn compile(path_name: &str, matches: &ArgMatches) {
 
 	// optimize::optimize(&mut ir);
 
-	if matches.get_flag("lnr") {
+	if true {
 		let disassembler = Disassembler::new(&ctx.type_store);
 		println!();
 		let mut ir_text = String::new();
 		disassembler.disassemble_program(&ir, &mut ir_text);
 		println!("{}", ir_text);
-		return;
 	}
 
 	// emit llvm

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -639,9 +639,9 @@ impl<'p> Parser<'p> {
 		let range = self.expect(Token::If)?;
 		self.expect(Token::LParen)?;
 		let cond = self.parse_expr(MIN_PDE)?;
-		self.expect_many(vec![Token::RParen, Token::LBrace])?;
+		self.expect_many(&[Token::RParen, Token::LBrace])?;
 		let then = self.parse_expr(MIN_PDE)?;
-		self.expect_many(vec![Token::RBrace, Token::Else, Token::LBrace])?;
+		self.expect_many(&[Token::RBrace, Token::Else, Token::LBrace])?;
 		let otherwise = self.parse_expr(MIN_PDE)?;
 		self.expect(Token::RBrace)?;
 		Ok(ast::IfExpr::new(Box::new(cond), Box::new(then), Box::new(otherwise), range))
@@ -795,15 +795,14 @@ impl<'p> Parser<'p> {
 		}
 	}
 
-	fn expect_many(&mut self, tokens: Vec<Token>) -> MessageResult<Range> {
-		Ok(if tokens.is_empty() {
-			Range::default()
-		} else {
-			tokens
-				.iter()
-				.skip(1)
-				.try_fold(self.expect(tokens[0])?, |acc, &t| Ok(acc.merged_with(&self.expect(t)?)))?
-		})
+	fn expect_many(&mut self, tokens: &[Token]) -> MessageResult<Option<Range>> {
+		let mut tokens = tokens.iter().copied();
+		let Some(first) = tokens.next() else {
+			return Ok(None);
+		};
+		tokens
+			.try_fold(self.expect(first)?, |acc, token| Ok(acc.merged_with(&self.expect(token)?)))
+			.map(Some)
 	}
 
 	fn expect(&mut self, token: Token) -> MessageResult<Range> {


### PR DESCRIPTION
## Add support for `if` expressions (ternary-like operator)

This PR introduces support for `if` expressions, allowing conditional assignment in expression form, similar to the ternary operator in other languages.

### ✅ Example usage:
```rust
let num = if(cond) { then_expr } else { otherwise_expr };
